### PR TITLE
proceed to checkout button disable in minicart when input/select qty …

### DIFF
--- a/react/components/QuantitySelector.tsx
+++ b/react/components/QuantitySelector.tsx
@@ -155,7 +155,14 @@ const QuantitySelector: FC<Props> = ({
   }
 
   const handleInputBlur = () => {
-    setInputFocused(false)
+    setInputFocused(false);
+
+    const proceedButton = document.getElementById('proceed-to-checkout') as HTMLButtonElement;
+    if (proceedButton) {
+      proceedButton.disabled = false;
+      proceedButton.style.backgroundColor = '';
+      proceedButton.style.cursor = 'pointer';
+    }
 
     if (curDisplayValue === '') {
       setDisplayValue(
@@ -183,7 +190,14 @@ const QuantitySelector: FC<Props> = ({
   }
 
   const handleInputFocus = () => {
-    setInputFocused(true)
+    setInputFocused(true);
+
+    const proceedButton = document.getElementById('proceed-to-checkout') as HTMLButtonElement;
+    if (proceedButton) {
+      proceedButton.disabled = true;
+      proceedButton.style.backgroundColor = 'gray';
+      proceedButton.style.cursor = 'not-allowed';
+    }
   }
 
   useEffect(() => {
@@ -232,6 +246,8 @@ const QuantitySelector: FC<Props> = ({
             size="small"
             value={normalizedValue}
             onChange={handleDropdownChange}
+            onFocus={handleInputFocus}
+            onBlur={handleInputBlur}
             placeholder=" "
             disabled={disabled}
           />
@@ -243,6 +259,8 @@ const QuantitySelector: FC<Props> = ({
             options={dropdownOptions}
             value={normalizedValue}
             onChange={handleDropdownChange}
+            onFocus={handleInputFocus}
+            onBlur={handleInputBlur}
             placeholder=" "
             disabled={disabled}
           />


### PR DESCRIPTION
#### What problem is this solving?

Proceed to checkout button disable in minicart when input/select qty are focused

#### How to test it?

In minicart, click on input/select qty elements in order to have the proceed-to-checkout button disabled

[Workspace] (https://test3--auchanqa.myvtex.com/ )

#### Screenshots or example usage:

![image](https://github.com/AuchanRomania/auchan-product-list/assets/152961179/79e9c286-117a-4779-a3f5-08ef2924a880)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
